### PR TITLE
Add focused qBittorrent Web API compatibility layer for PyMedusa

### DIFF
--- a/src/app/data/downloadClient.ts
+++ b/src/app/data/downloadClient.ts
@@ -82,20 +82,22 @@ export function setCategory(hash: string, category: string) {
   }
 }
 
-export async function remove(hashes: string[]) {
+export async function remove(hashes: string[], deleteFiles = true) {
   if (hashes.length) {
     const downloads = await amuleGetDownloads()
     const shared = await amuleGetShared()
+    const allHashes = [...downloads, ...shared].map((v) => v.hash)
+    const resolvedHashes = hashes.includes("ALL") ? allHashes : hashes
 
     await Promise.all(
-      hashes.map(async (hash) => {
+      resolvedHashes.map(async (hash) => {
         const file =
           downloads.find((v) => v.hash === hash) ??
           shared.find((v) => v.hash === hash)
 
         await amuleDoDelete(hash)
 
-        if (file) {
+        if (deleteFiles && file) {
           await unlink(`/downloads/complete/${file.name}`).catch(() => void 0)
           await unlink(`/tmp/shared/${file.name}`).catch(() => void 0)
         }

--- a/src/app/routes/api.v2.app.preferences.tsx
+++ b/src/app/routes/api.v2.app.preferences.tsx
@@ -5,6 +5,8 @@ export const loader = (() =>
     save_path: "/downloads/complete",
     temp_path_enabled: true,
     temp_path: "/downloads/incomplete",
+    queueing_enabled: false,
+    use_category_paths_in_manual_mode: false,
     create_subfolder_enabled: false,
     max_ratio_enabled: true,
     max_ratio: 0,

--- a/src/app/routes/api.v2.app.version.tsx
+++ b/src/app/routes/api.v2.app.version.tsx
@@ -1,11 +1,13 @@
 import { LoaderFunction } from "@remix-run/node"
 
 export const loader = (() =>
-  new Response(`2.8.0`, {
+  new Response("4.6.0", {
     status: 200,
     headers: {
-      "Content-Type": "text",
+      "Content-Type": "text/plain",
       "X-Content-Type-Options": "nosniff",
       "Cache-Control": "public, max-age=0",
     },
   })) satisfies LoaderFunction
+
+export const action = loader

--- a/src/app/routes/api.v2.auth.login.tsx
+++ b/src/app/routes/api.v2.auth.login.tsx
@@ -5,8 +5,8 @@ export const action = (async ({ request }) => {
   const password = formData.get("password")
 
   if (process.env.PASSWORD !== "" && process.env.PASSWORD !== password) {
-    return new Response(``, {
-      status: 401,
+    return new Response(`Fails.`, {
+      status: 200,
       headers: {
         "Content-Type": "text/plain",
         "X-Content-Type-Options": "nosniff",

--- a/src/app/routes/api.v2.auth.logout.tsx
+++ b/src/app/routes/api.v2.auth.logout.tsx
@@ -1,0 +1,12 @@
+import { ActionFunction } from "@remix-run/node"
+
+export const action = (() =>
+  new Response("Ok.", {
+    status: 200,
+    headers: {
+      "Content-Type": "text/plain",
+      "Set-Cookie": "SID=; Max-Age=0; path=/",
+      "X-Content-Type-Options": "nosniff",
+      "Cache-Control": "public, max-age=0",
+    },
+  })) satisfies ActionFunction

--- a/src/app/routes/api.v2.torrents.add.tsx
+++ b/src/app/routes/api.v2.torrents.add.tsx
@@ -1,6 +1,6 @@
 import { ActionFunction } from "@remix-run/node"
 import { download } from "~/data/downloadClient"
-import { fromMagnetLink } from "~/links"
+import { fromEd2kLink, fromMagnetLink } from "~/links"
 import { logger } from "~/utils/logger"
 
 export const action = (async ({ request }) => {
@@ -8,7 +8,6 @@ export const action = (async ({ request }) => {
   const formData = await request.formData()
   const rawUrls = formData.get("urls")?.toString() ?? ""
   const category = formData.get("category")?.toString() ?? ""
-  formData.get("savepath")?.toString()
 
   const urls = rawUrls
     .split("\n")
@@ -21,7 +20,7 @@ export const action = (async ({ request }) => {
 
   for (const url of urls) {
     try {
-      const { hash, name, size } = fromMagnetLink(url)
+      const { hash, name, size } = url.startsWith("ed2k://") ? fromEd2kLink(url) : fromMagnetLink(url)
       await download(hash, name, size, category)
     } catch {
       return new Response("Fails.", { status: 200, headers: { "Content-Type": "text/plain" } })

--- a/src/app/routes/api.v2.torrents.add.tsx
+++ b/src/app/routes/api.v2.torrents.add.tsx
@@ -1,4 +1,4 @@
-import { ActionFunction, json } from "@remix-run/node"
+import { ActionFunction } from "@remix-run/node"
 import { download } from "~/data/downloadClient"
 import { fromMagnetLink } from "~/links"
 import { logger } from "~/utils/logger"
@@ -6,19 +6,27 @@ import { logger } from "~/utils/logger"
 export const action = (async ({ request }) => {
   logger.debug("URL", request.url)
   const formData = await request.formData()
-  const urls = formData.get("urls")?.toString()
-  const category = formData.get("category")?.toString()
+  const rawUrls = formData.get("urls")?.toString() ?? ""
+  const category = formData.get("category")?.toString() ?? ""
+  formData.get("savepath")?.toString()
 
-  if (!urls) {
-    throw new Error("No URL to download")
+  const urls = rawUrls
+    .split("\n")
+    .map((v) => v.trim())
+    .filter(Boolean)
+
+  if (!urls.length) {
+    return new Response("Fails.", { status: 200, headers: { "Content-Type": "text/plain" } })
   }
 
-  if (!category) {
-    throw new Error("No download category")
+  for (const url of urls) {
+    try {
+      const { hash, name, size } = fromMagnetLink(url)
+      await download(hash, name, size, category)
+    } catch {
+      return new Response("Fails.", { status: 200, headers: { "Content-Type": "text/plain" } })
+    }
   }
 
-  const { hash, name, size } = fromMagnetLink(urls)
-  await download(hash, name, size, category)
-
-  return json({})
+  return new Response("Ok.", { status: 200, headers: { "Content-Type": "text/plain" } })
 }) satisfies ActionFunction

--- a/src/app/routes/api.v2.torrents.categories.tsx
+++ b/src/app/routes/api.v2.torrents.categories.tsx
@@ -5,7 +5,9 @@ export const loader = (async () => {
   const categories = await getCategories()
 
   return json(
-    Object.fromEntries(categories.map((c) => [c, { name: c, savePath: "" }]))
+    Object.fromEntries(
+      categories.map((c) => [c, { name: c, savePath: "/downloads/complete" }])
+    )
   )
 }) satisfies LoaderFunction
 

--- a/src/app/routes/api.v2.torrents.delete.tsx
+++ b/src/app/routes/api.v2.torrents.delete.tsx
@@ -7,7 +7,8 @@ export const action = (async ({ request }) => {
   logger.debug("URL", request.url)
   const formData = await request.formData()
   const hashesParam = formData.get("hashes")?.toString()?.toUpperCase()
-  const deleteFiles = formData.get("deleteFiles")?.toString() === "true"
+  const rawDeleteFiles = formData.get("deleteFiles")
+  const deleteFiles = rawDeleteFiles === null ? true : rawDeleteFiles.toString() === "true"
 
   const hashes =
     hashesParam === "ALL"

--- a/src/app/routes/api.v2.torrents.delete.tsx
+++ b/src/app/routes/api.v2.torrents.delete.tsx
@@ -1,4 +1,4 @@
-import { ActionFunction, json } from "@remix-run/node"
+import { ActionFunction } from "@remix-run/node"
 import { remove } from "~/data/downloadClient"
 import { skipFalsy } from "~/utils/array"
 import { logger } from "~/utils/logger"
@@ -6,16 +6,17 @@ import { logger } from "~/utils/logger"
 export const action = (async ({ request }) => {
   logger.debug("URL", request.url)
   const formData = await request.formData()
-  const hashes = formData
-    .get("hashes")
-    ?.toString()
-    ?.toUpperCase()
-    ?.split("|")
-    .filter(skipFalsy)
+  const hashesParam = formData.get("hashes")?.toString()?.toUpperCase()
+  const deleteFiles = formData.get("deleteFiles")?.toString() === "true"
+
+  const hashes =
+    hashesParam === "ALL"
+      ? ["ALL"]
+      : hashesParam?.split("|").filter(skipFalsy)
 
   if (hashes?.length) {
-    await remove(hashes)
+    await remove(hashes, deleteFiles)
   }
 
-  return json({})
+  return new Response("Ok.", { status: 200, headers: { "Content-Type": "text/plain" } })
 }) satisfies ActionFunction

--- a/src/app/routes/api.v2.torrents.info.tsx
+++ b/src/app/routes/api.v2.torrents.info.tsx
@@ -15,7 +15,9 @@ export const loader = (async ({ request }) => {
       .filter((d) => !category || d.meta?.category === category)
       .map((f) => {
         const isComplete = f.progress >= 1
-        const completedAt = isComplete ? Math.floor(Date.now() / 1000) : 0
+        const completedAt = isComplete
+          ? f.last_seen_complete || (f.meta?.addedOn ? Math.floor(f.meta.addedOn / 1000) : 0)
+          : 0
         const addedAt = f.meta?.addedOn ? Math.floor(f.meta.addedOn / 1000) : Math.floor(Date.now() / 1000)
         const contentPathValue = contentPath(f.name, isComplete)
         return {
@@ -60,6 +62,10 @@ function statusToQbittorrentState(status: Awaited<ReturnType<typeof amuleGetDown
       return "pausedDL"
     case "error":
       return "error"
+    case "completing":
+      return "checkingDL"
+    case "stalled":
+      return "stalledDL"
     default:
       return "stalledDL"
   }

--- a/src/app/routes/api.v2.torrents.info.tsx
+++ b/src/app/routes/api.v2.torrents.info.tsx
@@ -10,57 +10,57 @@ export const loader = (async ({ request }) => {
   const category = url.searchParams.get("category")
   const files = await getDownloadClientFiles()
 
-  return json([
-    ...files
-      .filter((d) => {
-        return !category || d.meta?.category === category
+  return json(
+    files
+      .filter((d) => !category || d.meta?.category === category)
+      .map((f) => {
+        const isComplete = f.progress >= 1
+        const completedAt = isComplete ? Math.floor(Date.now() / 1000) : 0
+        const addedAt = f.meta?.addedOn ? Math.floor(f.meta.addedOn / 1000) : Math.floor(Date.now() / 1000)
+        const contentPathValue = contentPath(f.name, isComplete)
+        return {
+          hash: f.hash,
+          name: f.name,
+          size: f.size,
+          progress: isComplete ? 1 : Math.min(0.999, Math.max(f.progress, 0.001)),
+          state: statusToQbittorrentState(f.status_str),
+          category: f.meta?.category ?? "",
+          save_path: "/downloads/complete",
+          content_path: contentPathValue,
+          completion_on: completedAt,
+          added_on: addedAt,
+          amount_left: isComplete ? 0 : Math.max(0, f.size - f.size_done),
+          dlspeed: f.speed ?? 0,
+          upspeed: f.up_speed ?? 0,
+          eta: f.eta ?? 0,
+          ratio: 0,
+          completed: isComplete ? f.size : f.size_done,
+          seen_complete: completedAt,
+        }
       })
-      .map((f) => ({
-        // qBittorrent structure
-        hash: f.hash,
-        name: f.name,
-        size: f.size,
-        size_done: f.size_done,
-        progress:
-          f.progress === 1 ? 1 : Math.min(0.999, Math.max(f.progress, 0.001)),
-        dlspeed: f.speed,
-        eta: f.eta,
-        state: statusToQbittorrentState(f.status_str),
-        content_path: contentPath(f.name),
-        category: f.meta?.category,
-      })),
-  ])
+  )
 }) satisfies LoaderFunction
 
 export const action = loader
 
-function contentPath(name: string) {
-  if (existsSync(`/downloads/complete/${name}`)) {
-    return `/downloads/complete/${name}`
-  }
-
-  if (existsSync(`/tmp/shared/${name}`)) {
-    return `/tmp/shared/${name}`
-  }
-
-  return undefined
+function contentPath(name: string, isComplete: boolean) {
+  if (!isComplete) return `/downloads/incomplete/${name}`
+  if (existsSync(`/downloads/complete/${name}`)) return `/downloads/complete/${name}`
+  if (existsSync(`/tmp/shared/${name}`)) return `/tmp/shared/${name}`
+  return `/downloads/complete/${name}`
 }
 
-function statusToQbittorrentState(
-  status: Awaited<ReturnType<typeof amuleGetDownloads>>[0]["status_str"]
-) {
+function statusToQbittorrentState(status: Awaited<ReturnType<typeof amuleGetDownloads>>[0]["status_str"]) {
   switch (status) {
     case "downloading":
       return "downloading"
     case "downloaded":
-      return "pausedUP"
-    case "stalled":
-      return "stalledDL"
-    case "error":
-      return "error"
-    case "completing":
-      return "moving"
+      return "uploading"
     case "stopped":
       return "pausedDL"
+    case "error":
+      return "error"
+    default:
+      return "stalledDL"
   }
 }

--- a/src/app/routes/api.v2.torrents.pause.tsx
+++ b/src/app/routes/api.v2.torrents.pause.tsx
@@ -1,0 +1,7 @@
+import { ActionFunction } from "@remix-run/node"
+
+export const action = (() =>
+  new Response("Ok.", {
+    status: 200,
+    headers: { "Content-Type": "text/plain" },
+  })) satisfies ActionFunction

--- a/src/app/routes/api.v2.torrents.properties.tsx
+++ b/src/app/routes/api.v2.torrents.properties.tsx
@@ -6,7 +6,10 @@ export const loader = (async ({ request }) => {
   const file = (await getDownloadClientFiles()).find((f) => f.hash === hash)
   const now = Math.floor(Date.now() / 1000)
   const added = file?.meta?.addedOn ? Math.floor(file.meta.addedOn / 1000) : now
-  const complete = file?.progress === 1 ? now : 0
+  const complete =
+    file?.progress === 1
+      ? file.last_seen_complete || (file.meta?.addedOn ? Math.floor(file.meta.addedOn / 1000) : 0)
+      : 0
 
   return json({
     save_path: "/downloads/complete",

--- a/src/app/routes/api.v2.torrents.properties.tsx
+++ b/src/app/routes/api.v2.torrents.properties.tsx
@@ -1,0 +1,39 @@
+import { LoaderFunction, json } from "@remix-run/node"
+import { getDownloadClientFiles } from "~/data/downloadClient"
+
+export const loader = (async ({ request }) => {
+  const hash = new URL(request.url).searchParams.get("hash")?.toUpperCase()
+  const file = (await getDownloadClientFiles()).find((f) => f.hash === hash)
+  const now = Math.floor(Date.now() / 1000)
+  const added = file?.meta?.addedOn ? Math.floor(file.meta.addedOn / 1000) : now
+  const complete = file?.progress === 1 ? now : 0
+
+  return json({
+    save_path: "/downloads/complete",
+    creation_date: 0,
+    piece_size: 0,
+    comment: "",
+    total_wasted: 0,
+    total_uploaded: 0,
+    total_uploaded_session: 0,
+    total_downloaded: file?.size_done ?? 0,
+    total_downloaded_session: 0,
+    up_limit: 0,
+    dl_limit: 0,
+    time_elapsed: Math.max(0, now - added),
+    seeding_time: complete ? Math.max(0, now - complete) : 0,
+    nb_connections: 0,
+    nb_connections_limit: 0,
+    share_ratio: 0,
+    addition_date: added,
+    completion_date: complete,
+    created_by: "eMulerr",
+    dl_speed_avg: file?.speed ?? 0,
+    dl_speed: file?.speed ?? 0,
+    eta: file?.eta ?? 0,
+    last_seen: complete,
+    peers: 0,
+    seeds: 0,
+    total_size: file?.size ?? 0,
+  })
+}) satisfies LoaderFunction

--- a/src/app/routes/api.v2.torrents.reannounce.tsx
+++ b/src/app/routes/api.v2.torrents.reannounce.tsx
@@ -1,0 +1,7 @@
+import { ActionFunction } from "@remix-run/node"
+
+export const action = (() =>
+  new Response("Ok.", {
+    status: 200,
+    headers: { "Content-Type": "text/plain" },
+  })) satisfies ActionFunction

--- a/src/app/routes/api.v2.torrents.recheck.tsx
+++ b/src/app/routes/api.v2.torrents.recheck.tsx
@@ -1,0 +1,7 @@
+import { ActionFunction } from "@remix-run/node"
+
+export const action = (() =>
+  new Response("Ok.", {
+    status: 200,
+    headers: { "Content-Type": "text/plain" },
+  })) satisfies ActionFunction

--- a/src/app/routes/api.v2.torrents.resume.tsx
+++ b/src/app/routes/api.v2.torrents.resume.tsx
@@ -1,0 +1,7 @@
+import { ActionFunction } from "@remix-run/node"
+
+export const action = (() =>
+  new Response("Ok.", {
+    status: 200,
+    headers: { "Content-Type": "text/plain" },
+  })) satisfies ActionFunction

--- a/src/app/routes/api.v2.transfer.info.tsx
+++ b/src/app/routes/api.v2.transfer.info.tsx
@@ -1,0 +1,15 @@
+import { LoaderFunction, json } from "@remix-run/node"
+
+export const loader = (() =>
+  json({
+    dl_info_speed: 0,
+    up_info_speed: 0,
+    dl_info_data: 0,
+    up_info_data: 0,
+    dl_rate_limit: 0,
+    up_rate_limit: 0,
+    dht_nodes: 0,
+    connection_status: "connected",
+  })) satisfies LoaderFunction
+
+export const action = loader

--- a/src/scripts/pymedusa-qb-compat-check.sh
+++ b/src/scripts/pymedusa-qb-compat-check.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+BASE_URL="${1:-http://localhost:3000}"
+PASSWORD="${PASSWORD:-}"
+ED2K_SAMPLE='ed2k://|file|sample.mkv|1234|0123456789ABCDEF0123456789ABCDEF|/'
+
+echo "== login =="
+curl -sS -X POST "$BASE_URL/api/v2/auth/login" -d "password=$PASSWORD"
+echo
+
+echo "== app version =="
+curl -sS "$BASE_URL/api/v2/app/version"; echo
+curl -sS "$BASE_URL/api/v2/app/webapiVersion"; echo
+curl -sS "$BASE_URL/api/v2/app/preferences"; echo
+
+echo "== categories =="
+curl -sS -X POST "$BASE_URL/api/v2/torrents/createCategory" -d "category=medusa"; echo
+curl -sS "$BASE_URL/api/v2/torrents/categories"; echo
+
+echo "== add ed2k =="
+curl -sS -X POST "$BASE_URL/api/v2/torrents/add" --data-urlencode "urls=$ED2K_SAMPLE" -d "category=medusa" -d "savepath=/downloads/complete"; echo
+
+echo "== info =="
+curl -sS "$BASE_URL/api/v2/torrents/info?category=medusa"; echo

--- a/src/scripts/pymedusa-qb-compat-check.sh
+++ b/src/scripts/pymedusa-qb-compat-check.sh
@@ -3,22 +3,24 @@ set -euo pipefail
 BASE_URL="${1:-http://localhost:3000}"
 PASSWORD="${PASSWORD:-}"
 ED2K_SAMPLE='ed2k://|file|sample.mkv|1234|0123456789ABCDEF0123456789ABCDEF|/'
+COOKIE_JAR=$(mktemp)
+trap 'rm -f "$COOKIE_JAR"' EXIT
 
 echo "== login =="
-curl -sS -X POST "$BASE_URL/api/v2/auth/login" -d "password=$PASSWORD"
+curl -sS -c "$COOKIE_JAR" -X POST "$BASE_URL/api/v2/auth/login" -d "password=$PASSWORD"
 echo
 
 echo "== app version =="
-curl -sS "$BASE_URL/api/v2/app/version"; echo
-curl -sS "$BASE_URL/api/v2/app/webapiVersion"; echo
-curl -sS "$BASE_URL/api/v2/app/preferences"; echo
+curl -sS -b "$COOKIE_JAR" "$BASE_URL/api/v2/app/version"; echo
+curl -sS -b "$COOKIE_JAR" "$BASE_URL/api/v2/app/webapiVersion"; echo
+curl -sS -b "$COOKIE_JAR" "$BASE_URL/api/v2/app/preferences"; echo
 
 echo "== categories =="
-curl -sS -X POST "$BASE_URL/api/v2/torrents/createCategory" -d "category=medusa"; echo
-curl -sS "$BASE_URL/api/v2/torrents/categories"; echo
+curl -sS -b "$COOKIE_JAR" -X POST "$BASE_URL/api/v2/torrents/createCategory" -d "category=medusa"; echo
+curl -sS -b "$COOKIE_JAR" "$BASE_URL/api/v2/torrents/categories"; echo
 
 echo "== add ed2k =="
-curl -sS -X POST "$BASE_URL/api/v2/torrents/add" --data-urlencode "urls=$ED2K_SAMPLE" -d "category=medusa" -d "savepath=/downloads/complete"; echo
+curl -sS -b "$COOKIE_JAR" -X POST "$BASE_URL/api/v2/torrents/add" --data-urlencode "urls=$ED2K_SAMPLE" -d "category=medusa" -d "savepath=/downloads/complete"; echo
 
 echo "== info =="
-curl -sS "$BASE_URL/api/v2/torrents/info?category=medusa"; echo
+curl -sS -b "$COOKIE_JAR" "$BASE_URL/api/v2/torrents/info?category=medusa"; echo


### PR DESCRIPTION
### Motivation
- Expose a minimal qBittorrent-like Web API so PyMedusa can connect, add ed2k/magnet downloads with a `medusa` category, poll status, and detect completed files under `/downloads/complete` for post-processing.
- Provide safe qBittorrent-compatible defaults and no-op endpoints to avoid breaking existing eMulerr/aMule behavior while satisfying PyMedusa expectations.

### Description
- Implemented qBittorrent-style auth endpoints with plain-text responses (`Ok.` / `Fails.`) and added logout that clears the `SID` cookie, preserving empty-password behavior in `src/app/routes/api.v2.auth.login.tsx` and `src/app/routes/api.v2.auth.logout.tsx`.
- Added app capability endpoints and safe preferences (`/api/v2/app/version`, `/api/v2/app/webapiVersion`, `/api/v2/app/preferences`) returning qBittorrent-like values and extra flags expected by PyMedusa in `src/app/routes/`.
- Extended torrent add handling in `src/app/routes/api.v2.torrents.add.tsx` to accept newline-separated `urls`, `category`, and `savepath`, return `Ok.`/`Fails.` text responses, and tolerate ignored qBittorrent fields; updated categories output to provide `savePath: "/downloads/complete"` in `src/app/routes/api.v2.torrents.categories.tsx`.
- Expanded torrent listing and properties to qBittorrent-compatible shapes (fields like `hash`, `name`, `progress`, `state`, `save_path`, `content_path`, `completion_on`, `added_on`, `amount_left`, etc.) in `src/app/routes/api.v2.torrents.info.tsx` and `src/app/routes/api.v2.torrents.properties.tsx`, with state mapping and safe defaults.
- Implemented delete semantics supporting `hashes=all`, multiple `|`-separated hashes, and `deleteFiles=true|false`, and updated `remove` in `src/app/data/downloadClient.ts` to accept a `deleteFiles` flag and resolve `ALL` hashes safely while preserving metadata behavior.
- Added safe no-op handlers for `pause`, `resume`, `recheck`, `reannounce` and a `transfer/info` endpoint to avoid PyMedusa failures; and added a manual smoke-test script at `src/scripts/pymedusa-qb-compat-check.sh` to exercise the main flows.

### Testing
- Ran TypeScript typecheck successfully with `cd src && npm run typecheck` and no type errors were reported.
- Added a manual compatibility smoke-test script at `src/scripts/pymedusa-qb-compat-check.sh` that exercises `POST /api/v2/auth/login`, `GET /api/v2/app/*`, category creation, `POST /api/v2/torrents/add`, and `GET /api/v2/torrents/info` for local validation (script created but not executed in CI here).
- No new automated unit tests were added; changes are implemented as a compatibility layer to avoid altering existing UI or aMule integration behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02fe9750348324ba64a5fe3871f350)